### PR TITLE
Extend entry point compatibility with tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,12 @@
     "browser": "./dist/js/iife/alwan.min.js",
     "typings": "./dist/js/types/src/index.d.ts",
     "type": "module",
-    ".": {
-        "import": "./dist/js/esm/alwan.min.js",
-        "require": "./dist/js/alwan.min.js"
+    "exports": {
+        ".": {
+            "types": "./dist/js/types/src/index.d.ts",
+            "import": "./dist/js/esm/alwan.min.js",
+            "require": "./dist/js/alwan.min.js"
+        }
     },
     "scripts": {
         "start": "rollup -c -w",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "main": "./dist/js/alwan.min.js",
     "module": "./dist/js/esm/alwan.min.js",
     "browser": "./dist/js/iife/alwan.min.js",
+    "style": "./dist/css/alwan.min.css",
     "typings": "./dist/js/types/src/index.d.ts",
     "type": "module",
     "exports": {


### PR DESCRIPTION
 * Use correct main entry point export syntax as defined on https://nodejs.org/api/packages.html#main-entry-point-export
 * Add `style` package.json field for custom toolings (not specified anywhere, but convention across many build tools)